### PR TITLE
optimize get_account_history_by_operations API 

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -301,17 +301,15 @@ namespace graphene { namespace app {
        hkey.sequence = std::numeric_limits<int64_t>::min();
 
        uint32_t count = 0;
-       order_history_object oho;
-       auto itr = history_idx.lower_bound( &hkey, sizeof(hkey), oho );
+       auto itr = history_idx.lower_bound( &hkey, sizeof(hkey));
        vector<order_history_object> result;
-       while( itr != nullptr && count < limit)
+       while( itr != history_idx.end() && count < limit)
        {
-          if( oho.key.base != a || oho.key.quote != b ) break;
-          result.push_back( oho );
+          if(itr->key.base != a || itr->key.quote != b ) break;
+          result.push_back( *itr );
+          ++itr;
           ++count;
-          if (!history_idx.get_next(itr, oho)) break;
        }
-       history_idx.close_cursor(itr);
 
        return result;
     }
@@ -338,28 +336,24 @@ namespace graphene { namespace app {
        const auto& hist_idx = dynamic_cast<const bdb_index<account_transaction_history_object>&>(db.get_index(account_transaction_history_object::space_id, account_transaction_history_object::type_id));
        const auto& by_op_idx = hist_idx.get_bdb_secondary_index(1);
 
-       account_transaction_history_object obj;
        atho_by_op key;
        key.account = account;
        key.operation_id = start;
-       auto itr = by_op_idx.lower_bound(&key, sizeof(key), obj);
+       auto itr = by_op_idx.lower_bound(&key, sizeof(key));
 
-       while(itr != nullptr && obj.account == account && obj.operation_id.instance.value > stop.instance.value && result.size() < limit)
+       while(itr != by_op_idx.end() && itr->account == account && itr->operation_id.instance.value > stop.instance.value && result.size() < limit)
        {
-           if (obj.operation_id.instance.value <= start.instance.value)
+           if (itr->operation_id.instance.value <= start.instance.value)
            {
-               auto oho = db.find_db(obj.operation_id);
+               auto oho = db.find_db(itr->operation_id);
                result.push_back(*oho);
-           }
-          
-           if(!by_op_idx.get_previous(itr, obj))
-               break;
+           }          
+           --itr;
        }
-       if(stop.instance.value == 0 && result.size() < limit && obj.account == account) {
-           auto oho = db.find_db(obj.operation_id);
+       if(stop.instance.value == 0 && result.size() < limit && itr->account == account) {
+           auto oho = db.find_db(itr->operation_id);
            result.push_back(*oho);
        }
-       by_op_idx.close_cursor(itr);
 
        return result;
     }
@@ -413,22 +407,22 @@ namespace graphene { namespace app {
 
 
     vector<operation_history_object> history_api::get_relative_account_history( account_id_type account,
-                                                                                uint32_t stop,
+                                                                                uint32_t start,
                                                                                 unsigned limit,
-                                                                                uint32_t start) const
+                                                                                uint32_t stop) const
     {
        FC_ASSERT( _app.chain_database() );
        const auto& db = *_app.chain_database();
        FC_ASSERT(limit <= 100);
        vector<operation_history_object> result;
        const auto& stats = account(db).statistics(db);
-       if( start == 0 )
-          start = stats.total_ops;
+       if(stop == 0 )
+          stop = stats.total_ops;
        else
-          start = min( stats.total_ops, start );
+          stop = min( stats.total_ops, stop);
 
 
-       if( start >= stop && start > stats.removed_ops && limit > 0 )
+       if(stop >= start && stop > stats.removed_ops && limit > 0 )
        {
           //const auto& hist_idx = db.get_index_type<account_transaction_history_index>();
           //const auto& by_seq_idx = hist_idx.indices().get<by_seq>();
@@ -438,22 +432,63 @@ namespace graphene { namespace app {
           // auto itr = by_seq_idx.upper_bound(boost::make_tuple(account, start));
           // auto itr_stop = by_seq_idx.lower_bound(boost::make_tuple(account, stop));
 
-          account_transaction_history_object obj;
           atho_by_seq key;
           key.account = account;
-          key.sequence = start;
-          auto itr = by_seq_idx.upper_bound(&key, sizeof(key), obj);
+          key.sequence = stop;
+          auto itr = by_seq_idx.upper_bound(&key, sizeof(key));
 
-          if( itr )
-          do
+          while( itr != by_seq_idx.end() && itr->account == account && itr->sequence >= start && result.size() < limit)
           {
-             auto oho = db.find_db(obj.operation_id);
-             result.push_back( *oho );  
-          }
-          while( obj.sequence > stop && result.size() < limit && by_seq_idx.get_previous(itr, obj) );
+             auto oho = db.find_db(itr->operation_id);
+             result.push_back( *oho );
+             --itr;
+          } 
        }
        return result;
     }
+
+
+    vector<operation_history_object> history_api::get_relative_account_history_by_ops(account_id_type account,
+                                                                                    vector<uint16_t> operation_types,
+                                                                                    uint32_t start,
+                                                                                    unsigned limit,
+                                                                                    size_t& total_count) const
+    {
+       FC_ASSERT(_app.chain_database());
+       const auto& db = *_app.chain_database();
+       FC_ASSERT(limit <= 100);
+       vector<operation_history_object> result;
+       const auto& stats = account(db).statistics(db);
+       uint32_t stop = stats.total_ops; 
+       total_count = stop;
+
+       if (stop >= start && stop > stats.removed_ops && limit > 0)
+       {
+          //const auto& hist_idx = db.get_index_type<account_transaction_history_index>();
+          //const auto& by_seq_idx = hist_idx.indices().get<by_seq>();
+          const auto& hist_idx = dynamic_cast<const bdb_index<account_transaction_history_object>&>(db.get_index(account_transaction_history_object::space_id, account_transaction_history_object::type_id));
+          const auto& by_seq_idx = hist_idx.get_bdb_secondary_index(0);
+
+          // auto itr = by_seq_idx.upper_bound(boost::make_tuple(account, start));
+          // auto itr_stop = by_seq_idx.lower_bound(boost::make_tuple(account, stop));
+
+          atho_by_seq key;
+          key.account = account;
+          key.sequence = stop;
+          auto itr = by_seq_idx.upper_bound(&key, sizeof(key));
+
+          while (itr != by_seq_idx.end() && itr->account == account && itr->sequence >= start && result.size() < limit)
+          {
+             auto oho = db.find_db(itr->operation_id);
+             if (operation_types.empty() || find(operation_types.begin(), operation_types.end(), oho->op.which()) != operation_types.end())
+               result.push_back(*oho);
+
+             --itr;
+          }
+       }
+       return result;
+    }
+
 
     flat_set<uint32_t> history_api::get_market_history_buckets()const
     {
@@ -466,14 +501,16 @@ namespace graphene { namespace app {
     {
         FC_ASSERT(limit <= 100);
         history_operation_detail result;
-        vector<operation_history_object> objs = get_relative_account_history(account, start, limit, limit + start - 1);
-        std::for_each(objs.begin(), objs.end(), [&](const operation_history_object &o) {
-                    if (operation_types.empty() || find(operation_types.begin(), operation_types.end(), o.op.which()) != operation_types.end()) {
-                        result.operation_history_objs.push_back(o);
-                     }
-                 });
-
-        result.total_count = objs.size();
+        size_t total_count=0;
+        // vector<operation_history_object> objs = get_relative_account_history(account, start, limit, limit + start - 1);
+        vector<operation_history_object> objs = get_relative_account_history_by_ops(account, operation_types, start, limit, total_count);
+        //std::for_each(objs.begin(), objs.end(), [&](const operation_history_object &o) {
+        //            if (operation_types.empty() || find(operation_types.begin(), operation_types.end(), o.op.which()) != operation_types.end()) {
+        //                result.operation_history_objs.push_back(o);
+        //             }
+        //         });
+        result.operation_history_objs = objs;
+        result.total_count = total_count;
         return result;
     }
 

--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -177,6 +177,13 @@ namespace graphene { namespace app {
                                                                         unsigned limit = 100,
                                                                         uint32_t start = 0) const;
 
+         vector<operation_history_object> get_relative_account_history_by_ops(account_id_type account,
+                                                                        vector<uint16_t> operation_types,
+                                                                        uint32_t start,
+                                                                        unsigned limit,
+                                                                        size_t& total_count) const;
+
+
          vector<order_history_object> get_fill_order_history( asset_id_type a, asset_id_type b, uint32_t limit )const;
          vector<bucket_object> get_market_history( asset_id_type a, asset_id_type b, uint32_t bucket_seconds,
                                                    fc::time_point_sec start, fc::time_point_sec end )const;

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -1131,17 +1131,14 @@ vector< graphene::market_history::order_history_object > database_fixture::get_m
    if( a > b ) std::swap(a,b);
    hkey.base = a;
    hkey.quote = b;
-   hkey.sequence = std::numeric_limits<int64_t>::min();
-   graphene::market_history::order_history_object oho;
-   auto itr = history_idx.lower_bound( &hkey, sizeof(hkey), oho );
+   hkey.sequence = std::numeric_limits<int64_t>::min(); 
+   auto itr = history_idx.lower_bound( &hkey, sizeof(hkey));
    vector<graphene::market_history::order_history_object> result;
-   while( itr != nullptr )
+   while( itr != history_idx.end())
    {
-       result.push_back( oho );
-       if (!history_idx.get_next(itr, oho)) break;
+       result.push_back( *itr );
+       ++itr;
    }
-   history_idx.close_cursor(itr);
-
    return result;
 }
 


### PR DESCRIPTION
optimize get_account_history_by_operations API; add compare function to bdb_index for operations table so the records are sorted in the order we desired